### PR TITLE
Allow object or string for src prop

### DIFF
--- a/src/LottiePlayer.vue
+++ b/src/LottiePlayer.vue
@@ -8,7 +8,7 @@ import '@lottiefiles/lottie-player';
 export default {
 	props: {
 		src: {
-			type: Object || String,
+			type: [Object, String],
 			required: true
 		},
 		options: {


### PR DESCRIPTION
as u can see at my commit, that syntax is wrong and give error :
```
[Vue warn]: Invalid prop: type check failed for prop "src". Expected Object, got String with value "https://assets1.lottiefiles.com/temp/lf20_USCruP.json"
```

ref : https://vuejs.org/v2/guide/components-props.html#Prop-Validation